### PR TITLE
#2 add factory method for better typing of matcher

### DIFF
--- a/src/main/java/org/objecttrouve/testing/matchers/ConvenientMatchers.java
+++ b/src/main/java/org/objecttrouve/testing/matchers/ConvenientMatchers.java
@@ -70,6 +70,19 @@ public class ConvenientMatchers {
     }
 
     /**
+     * <p>Factory method for a {@link FluentIterableMatcher}
+     * to match an <i>actual</i> {@code Iterable}'s properties.</p>
+     *
+     * @param iterable iterable to steal type from.
+     * @param <X> Expected type of the actual {@code Iterable}'s items.
+     * @param <C> Expected type of the actual {@code Iterable}.
+     * @return FluentAttributeMatcher.
+     */
+    public static <X, C extends Iterable<X>> FluentIterableMatcher<X, C> anIterableLike(final C iterable){
+        return defaultFactory.iterableLike(iterable);
+    }
+
+    /**
      * <p>Retrieve a {@link MatcherFactory} on which symbols, stringifiers and other settings can be configured.</p>
      * @return {@link MatcherFactory}*/
     public static MatcherFactory.Builder customized(){

--- a/src/main/java/org/objecttrouve/testing/matchers/customization/MatcherFactory.java
+++ b/src/main/java/org/objecttrouve/testing/matchers/customization/MatcherFactory.java
@@ -180,4 +180,16 @@ public class MatcherFactory {
         return FlimFactory.fluentIterableMatcher(klass, config);
     }
 
+    /**
+     * <p>Factory method for a {@link FluentIterableMatcher}
+     * to match an <i>actual</i> {@code Iterable}'s properties.</p>
+     *
+     * @param iterable for typping
+     * @param <C> expected type of the actual {@code Iterable}
+     * @return FluentAttributeMatcher for an actual iterable
+     */
+    public <X, C extends Iterable<X>> FluentIterableMatcher<X, C> iterableLike(final C iterable){
+        return FlimFactory.fluentIterableMatcherLike(iterable, config);
+    }
+
 }

--- a/src/main/java/org/objecttrouve/testing/matchers/fluentits/FlimFactory.java
+++ b/src/main/java/org/objecttrouve/testing/matchers/fluentits/FlimFactory.java
@@ -29,4 +29,19 @@ public class FlimFactory {
         return new FluentIterableMatcher<X, C>(klass, prose, config).debugging(config.isInDebugMode());
     }
 
+    /**
+     * <p>Factory method for a {@link FluentIterableMatcher}
+     * to match an <i>actual</i> {@code Iterable}'s properties.</p>
+     *
+     * @param iterable to steal type from
+     * @param <X> Expected type of the actual {@code Iterable}'s items.
+     * @param <C> Expected type of the actual {@code Iterable}.
+     * @param config The {@link Config} to apply to the matcher.
+     * @return FluentAttributeMatcher.
+     */
+    public static <X, C extends Iterable<X>> FluentIterableMatcher<X, C> fluentIterableMatcherLike(@SuppressWarnings("unused") final C iterable, final Config config){
+        final Prose<X> prose = new Prose<>(config.getSymbols(), config.getStringifiers());
+        return new FluentIterableMatcher<X, C>(null, prose, config).debugging(config.isInDebugMode());
+    }
+
 }

--- a/src/test/java/org/objecttrouve/testing/matchers/fluentits/FluentIterableMatcherTest.java
+++ b/src/test/java/org/objecttrouve/testing/matchers/fluentits/FluentIterableMatcherTest.java
@@ -7,9 +7,13 @@
 
 package org.objecttrouve.testing.matchers.fluentits;
 
+import java.util.LinkedList;
+import java.util.concurrent.atomic.AtomicReference;
 import org.hamcrest.StringDescription;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.objecttrouve.testing.matchers.ConvenientMatchers;
+import static org.objecttrouve.testing.matchers.ConvenientMatchers.anIterableLike;
 import org.objecttrouve.testing.matchers.customization.MatcherFactory;
 import org.objecttrouve.testing.matchers.fluentatts.Attribute;
 import org.objecttrouve.testing.matchers.fluentatts.FluentAttributeMatcher;
@@ -3501,4 +3505,66 @@ public class FluentIterableMatcherTest {
             fail("Length was " + length + ". Debug output changed in an unexpected way:\n\n" + issues);
         }
     }
+
+    @Test
+    public void factoryForBetterTyping() {
+
+        final List<AtomicReference<String>> refs = new LinkedList<>();
+        AtomicReference<String> ref = new AtomicReference<>("hello");
+        refs.add(ref);
+
+        assertThat(refs, is(anIterableLike(refs).withItems(ref)));
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static class Comp<C extends Comparable> implements Comparable<Comp>{
+        C c;
+
+        Comp(C c) {
+            this.c = c;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public int compareTo(@NotNull Comp comp) {
+            return c.compareTo(comp.c);
+        }
+    }
+
+    @Test
+    public void factoryForBetterTypingCanSort() {
+
+        final List<Comp<String>> refs = new LinkedList<>();
+        Comp<String> ref1 = new Comp<>("hello");
+        Comp<String> ref2 = new Comp<>("goodbye");
+        refs.add(ref2);
+        refs.add(ref1);
+
+        assertThat(refs, is(anIterableLike(refs).withItems(ref1).sorted()));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void factoryForBetterTypingCanSort2() {
+
+        final List<Comp<String>> refs = new LinkedList<>();
+        Comp<String> ref1 = new Comp<>("hello");
+        Comp<String> ref2 = new Comp<>("goodbye");
+        refs.add(ref1);
+        refs.add(ref2);
+
+        assertThat(refs, is(anIterableLike(refs).withItems(ref1).sorted()));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void factoryForBetterTypingNotComparable() {
+
+        final List<AtomicReference<String>> refs = new LinkedList<>();
+        AtomicReference<String> ref1 = new AtomicReference<>("a");
+        AtomicReference<String> ref2 = new AtomicReference<>("b");
+        refs.add(ref1);
+        refs.add(ref2);
+
+        assertThat(refs, is(anIterableLike(refs).withItems(ref2).sorted()));
+    }
+
 }


### PR DESCRIPTION
I added factory method for better typing so you can use like this without compile issue:

```
    @Test
    public void factoryForBetterTypingCanSort() {

        final List<Comp<String>> refs = new LinkedList<>();
        Comp<String> ref1 = new Comp<>("hello");
        Comp<String> ref2 = new Comp<>("goodbye");
        refs.add(ref2);
        refs.add(ref1);

        assertThat(refs, is(anIterableLike(refs).withItems(ref1).sorted()));
    }
```

made klass nullable but tested places that are affected